### PR TITLE
Elasticsearch: Added missing ignore_error option to Configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -419,6 +419,7 @@ class Configuration implements ConfigurationInterface
                             ->end() // elasticsearch
                             ->scalarNode('index')->defaultValue('monolog')->end() // elasticsearch
                             ->scalarNode('document_type')->defaultValue('logs')->end() // elasticsearch
+                            ->scalarNode('ignore_error')->defaultValue(false)->end() // elasticsearch
                             ->arrayNode('config')
                                 ->canBeUnset()
                                 ->prototype('scalar')->end()


### PR DESCRIPTION
The Parameter was missing.
